### PR TITLE
Fix methods to get compatibility with Rails5

### DIFF
--- a/lib/active_record/belongs_to_if/builder_extension.rb
+++ b/lib/active_record/belongs_to_if/builder_extension.rb
@@ -1,8 +1,21 @@
 module ActiveRecord
   module BelongsToIf
     module BuilderExtension
+      # To keep compatibility with Rails > 4
       def valid_options
         super + [:if]
+      end
+
+      module ClassMethods
+        def valid_options(options)
+          super + [:if]
+        end
+      end
+
+      def self.prepended(base)
+        class << base
+          prepend ClassMethods
+        end
       end
     end
   end

--- a/lib/active_record/belongs_to_if/preloader_extension.rb
+++ b/lib/active_record/belongs_to_if/preloader_extension.rb
@@ -28,28 +28,40 @@ module ActiveRecord
 
       # @note Override to change `records_by_owner` so that empty array is used.
       def associated_records_by_owner(preloader)
-        owners_map = owners_by_key
-        owner_keys = owners_map.keys.compact
-
         # Each record may have multiple owners, and vice-versa
         records_by_owner = Hash.new do |hash, key|
           hash[key] = []
         end
 
-        if owner_keys.any?
-          # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
-          # Make several smaller queries if necessary or make one query if the adapter supports it
-          sliced  = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
+        # To keep compatibility with Rails > 4
+        if ::ActiveRecord::VERSION::MAJOR > 4
+          records = load_records
+          records_by_owner = Hash.new do |hash, key|
+            hash[key] = []
+          end
+          owners.each_with_object(records_by_owner) do |owner, result|
+            result[owner] = records[convert_key(owner[owner_key_name])] || []
+          end
+        else
+          owners_map = owners_by_key
+          owner_keys = owners_map.keys.compact
 
-          records = load_slices sliced
-          records.each do |record, owner_key|
-            owners_map[owner_key].each do |owner|
-              records_by_owner[owner] << record
+
+          if owner_keys.any?
+            # Some databases impose a limit on the number of ids in a list (in Oracle it's 1000)
+            # Make several smaller queries if necessary or make one query if the adapter supports it
+            sliced  = owner_keys.each_slice(klass.connection.in_clause_length || owner_keys.size)
+
+            records = load_slices sliced
+            records.each do |record, owner_key|
+              owners_map[owner_key].each do |owner|
+                records_by_owner[owner] << record
+              end
             end
           end
-        end
 
-        records_by_owner
+          records_by_owner
+        end
       end
 
       # @return [Proc, String, Symbol, nil] The value :if option passed to belongs_to.


### PR DESCRIPTION
Since Rails5, some method that `activerecord-belongs_to_if` uses has been renamed or changed. 

here's some refs: 
- `valid_options` has been changed to `self.valid_options` in https://github.com/rails/rails/commit/78dab2a8569408658542e462a957ea5a35aa4679
-  `owners_by_key` has been removed since https://github.com/rails/rails/commit/6ec7baad52ad0de371194a3696b96ca46b527196

@r7kamura How about this change?
