### PR TITLE
Support ActiveRecord 5.2.0

### DIFF
--- a/lib/active_record/belongs_to_if/extend.rb
+++ b/lib/active_record/belongs_to_if/extend.rb
@@ -1,4 +1,8 @@
 ActiveSupport.on_load(:active_record) do
   ActiveRecord::Associations::Builder::BelongsTo.send(:prepend, ActiveRecord::BelongsToIf::BuilderExtension)
-  ActiveRecord::Associations::Preloader::BelongsTo.send(:prepend, ActiveRecord::BelongsToIf::PreloaderExtension)
+  if ActiveRecord.gem_version >= Gem::Version.new('5.2.0')
+    ActiveRecord::Associations::Preloader::Association.send(:prepend, ActiveRecord::BelongsToIf::PreloaderExtension)
+  else
+    ActiveRecord::Associations::Preloader::BelongsTo.send(:prepend, ActiveRecord::BelongsToIf::PreloaderExtension)
+  end
 end


### PR DESCRIPTION
Since ActiveRecord 5.2, Refactor ActiveRecord::Preloader associations. https://github.com/rails/rails/pull/31079